### PR TITLE
(maint) Pin to chocolatey 1.4

### DIFF
--- a/configs/platforms/windowsfips-2012r2-x64.rb
+++ b/configs/platforms/windowsfips-2012r2-x64.rb
@@ -3,7 +3,7 @@ platform 'windowsfips-2012r2-x64' do |plat|
   plat.servicetype 'windows'
 
   # We need to ensure we install chocolatey prior to adding any nuget repos. Otherwise, everything will fall over
-  plat.add_build_repository 'https://artifactory.delivery.puppetlabs.net/artifactory/generic/buildsources/windows/chocolatey/install-chocolatey.ps1'
+  plat.add_build_repository 'https://artifactory.delivery.puppetlabs.net/artifactory/generic/buildsources/windows/chocolatey/install-chocolatey-1.4.0.ps1'
   plat.provision_with 'C:/ProgramData/chocolatey/bin/choco.exe feature enable -n useFipsCompliantChecksums'
 
   plat.add_build_repository 'https://artifactory.delivery.puppetlabs.net/artifactory/api/nuget/nuget'
@@ -14,7 +14,6 @@ platform 'windowsfips-2012r2-x64' do |plat|
   plat.provision_with 'mkdir -p C:/tools'
 
   # We don't want to install any packages from the chocolatey repo by accident
-  plat.provision_with 'C:/ProgramData/chocolatey/bin/choco.exe upgrade -y chocolatey --no-progress'
   plat.provision_with 'C:/ProgramData/chocolatey/bin/choco.exe sources remove -name chocolatey'
 
   plat.provision_with 'C:/ProgramData/chocolatey/bin/choco.exe install -y mingw-w64 -version 5.2.0 -debug --no-progress'


### PR DESCRIPTION
Chocolatey 2.0 dropped the deprecated Get-BinRoot script which mingw-w64 relies on, so pin back to 1.4.0 for now. We also have to disable upgrades so we don't upgrade to 2.0.

See also puppetlabs/puppet-runtime@5a342f27844fb92a275bb37ba44e61a22c1df7af

- [x] [vanagon-generic-builder](https://jenkins-platform.delivery.puppetlabs.net/job/platform_vanagon-generic-builder_vanagon-packaging_generic-builder/BUILD_TARGET=windowsfips-2012r2-x64,SLAVE_LABEL=k8s-worker/2286)