### PR TITLE
(PE-36727) Adding openssl-fips-client-tools project

### DIFF
--- a/configs/projects/openssl-fips-client-tools.rb
+++ b/configs/projects/openssl-fips-client-tools.rb
@@ -1,0 +1,4 @@
+project 'openssl-fips-client-tools' do |proj|
+  prefix = 'client-tools'
+  instance_eval File.read(File.join(File.dirname(__FILE__), '_shared-openssl-fips.rb'))
+end 


### PR DESCRIPTION
Added openssl-fips-client-tools project to Build openssl-fips for PE client tools on RHEL7 FIPS & RHEL8 FIPS

- [x] [redhatfips-7-x86_64](https://jenkins-platform.delivery.puppetlabs.net/view/vanagon-generic-builder/job/platform_vanagon-generic-builder_vanagon-packaging_generic-builder/2289/BUILD_TARGET=redhatfips-7-x86_64,SLAVE_LABEL=k8s-worker/)
- [x] [redhatfips-8-x86_64](https://jenkins-platform.delivery.puppetlabs.net/view/vanagon-generic-builder/job/platform_vanagon-generic-builder_vanagon-packaging_generic-builder/2289/BUILD_TARGET=redhatfips-8-x86_64,SLAVE_LABEL=k8s-worker/)